### PR TITLE
feat(docker): support more arm variants

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -20,7 +20,7 @@ steps:
       tags: unstable
       cache_from: docker.io/cromrots/opa:cache
       cache_to: docker.io/cromrots/opa:cache
-      platform: linux/amd64,linux/arm64
+      platform: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7,linux/arm/v8
       password:
         from_secret: docker_pwd
       username:
@@ -58,7 +58,7 @@ steps:
       auto_tag: true
       cache_from: docker.io/cromrots/opa:cache
       cache_to: docker.io/cromrots/opa:cache
-      platform: linux/amd64,linux/arm64
+      platform: linux/amd64,linux/arm64,linux/arm/v6,linux/arm/v7,linux/arm/v8
       password:
         from_secret: docker_pwd
       username:
@@ -116,6 +116,6 @@ steps:
 
 ---
 kind: signature
-hmac: 12dea2cc7a0a71d7727acde3138ebf86a2e8e7f27f55dc6fbc42e5773f81e1b3
+hmac: 28cacd675a140321e7ce0fb84fa0411028033625739c95ebaa08d347f8142f85
 
 ...

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,31 @@
-FROM openpolicyagent/opa:0.50.1-static as opa
+FROM --platform=${BUILDPLATFORM} drone/git:1.2.1 as clone
+
+WORKDIR /tmp
+
+ARG GIT_TAG=v0.52.0
+
+RUN git clone \
+    --depth 1 \
+    --branch $GIT_TAG \
+    https://github.com/open-policy-agent/opa.git
+
+FROM --platform=${BUILDPLATFORM} golang:1.20 as build
+
+COPY --from=clone /tmp/opa ./opa
+
+ARG TARGETOS
+ARG TARGETARCH
+
+ENV CGO_ENABLED=0
+ENV GO111MODULE=on
+ENV GOOS=${TARGETOS}
+ENV GOARCH=${TARGETARCH}
+
+RUN cd opa && \
+    go build \
+        -o opa \
+        -ldflags "-s -w" \
+        main.go
 
 FROM --platform=${BUILDPLATFORM} alpine:3.17.0 AS nonroot
 
@@ -25,7 +52,7 @@ ENV UID=1000
 ENV GID=2000
 
 COPY --from=nonroot /etc/passwd /etc/passwd
-COPY --chown=$UID:$GID --from=opa /opa /
+COPY --chown=$UID:$GID --from=build /go/opa/opa /
 
 USER $UID
 


### PR DESCRIPTION
Now supporting:

* linux/amd64
* linux/arm64
* linux/arm/v6
* linux/arm/v7
* linux/arm/v8

Build the opa binary for each target, instead of copying the binary from the official docker images as not all architectures are supported.